### PR TITLE
perf: use `IMAS.trace_simple_surfaces` to improve performance

### DIFF
--- a/src/PAM.jl
+++ b/src/PAM.jl
@@ -659,14 +659,6 @@ end
     end
 end
 
-# Convenient dispatch to call IMAS's trace_simple_surfaces
-function IMAS.trace_simple_surfaces(eqt::IMAS.equilibrium__time_slice{T}, wall_r::AbstractVector{T}, wall_z::AbstractVector{T}) where {T<:Real}
-    eqt2d = findfirst(:rectangular, eqt.profiles_2d)
-    r, z, PSI_interpolant = IMAS.ψ_interpolant(eqt2d)
-    RA = eqt.global_quantities.magnetic_axis.r
-    ZA = eqt.global_quantities.magnetic_axis.z
-    return IMAS.trace_simple_surfaces(eqt.profiles_1d.psi, r, z, eqt2d.psi, PSI_interpolant, RA, ZA, wall_r, wall_z)
-end
 
 """
     run_PAM(dd::IMAS.dd; t_start::Float64, t_finish::Float64, time_step::Float64, drift_model::Symbol, Bt_dependance::Bool, update_plasma::Bool)

--- a/src/PAM.jl
+++ b/src/PAM.jl
@@ -24,7 +24,7 @@ mutable struct AllocationPool{T<:Real}
     nsource_max_len::Int
 end
 
-function AllocationPool(::Type{T}, surfaces::Vector{IMAS.FluxSurface}) where {T<:Real}
+function AllocationPool(::Type{T}, surfaces::Vector{<:IMAS.AbstractFluxSurface}) where {T<:Real}
     max_len = maximum(length(surf.r) for surf in surfaces)
     return AllocationPool{T}(Vector{T}(undef, max_len), max_len)
 end
@@ -58,7 +58,7 @@ function Pellet(
     eqt::IMAS.equilibrium__time_slice,
     cp1d::IMAS.core_profiles__profiles_1d,
     time::Vector{Float64},
-    surfaces::Vector{IMAS.FluxSurface},
+    surfaces::Vector{<:IMAS.AbstractFluxSurface},
     drift_model::Symbol,
     Bt_dependance::Bool,
     update_plasma::Bool
@@ -555,7 +555,7 @@ function dr_dt!(pelt::Pellet, k::Int)
     return
 end
 
-function pellet_density(pelt::Pellet, surface::IMAS.FluxSurface, k::Int)
+function pellet_density(pelt::Pellet, surface::IMAS.AbstractFluxSurface, k::Int)
     # Get buffer view from pool
     len = length(surface.r)
     nsource = @view pelt.pool.nsource_buffer[1:len]
@@ -583,7 +583,7 @@ function pellet_density(pelt::Pellet, surface::IMAS.FluxSurface, k::Int)
     return IMAS.flux_surface_avg(nsource, surface)
 end
 
-function ablate!(eqt::IMAS.equilibrium__time_slice, cp1d::IMAS.core_profiles__profiles_1d, pelt::Pellet, surfaces::Vector{IMAS.FluxSurface})
+function ablate!(eqt::IMAS.equilibrium__time_slice, cp1d::IMAS.core_profiles__profiles_1d, pelt::Pellet, surfaces::Vector{<:IMAS.AbstractFluxSurface})
     pellet_source = zeros(length(pelt.time), length(surfaces))
 
     for k in 2:length(pelt.time)
@@ -659,6 +659,15 @@ end
     end
 end
 
+# Convenient dispatch to call IMAS's trace_simple_surfaces
+function IMAS.trace_simple_surfaces(eqt::IMAS.equilibrium__time_slice{T}, wall_r::AbstractVector{T}, wall_z::AbstractVector{T}) where {T<:Real}
+    eqt2d = findfirst(:rectangular, eqt.profiles_2d)
+    r, z, PSI_interpolant = IMAS.ψ_interpolant(eqt2d)
+    RA = eqt.global_quantities.magnetic_axis.r
+    ZA = eqt.global_quantities.magnetic_axis.z
+    return IMAS.trace_simple_surfaces(eqt.profiles_1d.psi, r, z, eqt2d.psi, PSI_interpolant, RA, ZA, wall_r, wall_z)
+end
+
 """
     run_PAM(dd::IMAS.dd; t_start::Float64, t_finish::Float64, time_step::Float64, drift_model::Symbol, Bt_dependance::Bool, update_plasma::Bool)
 
@@ -672,7 +681,7 @@ function run_PAM(dd::IMAS.dd; t_start::Float64, t_finish::Float64, time_step::Fl
     time = collect(range(t_start, t_finish; step=time_step))
 
     # define flux surfaces, will be needed for the pellet source calculations
-    surfaces = IMAS.trace_surfaces(eqt, IMAS.first_wall(dd.wall)...)
+    surfaces = IMAS.trace_simple_surfaces(eqt, IMAS.first_wall(dd.wall)...)
 
     # initialize the pellet structure 
     pellet = Pellet(dd.pellets.time_slice[].pellet[1], eqt, cp1d, time, surfaces, drift_model, Bt_dependance, update_plasma)


### PR DESCRIPTION
## Prerequisite PR
https://github.com/ProjectTorreyPines/IMAS.jl/pull/282

## Summary
Replace `trace_surfaces` with `trace_simple_surfaces` for flux surface calculations, significantly reducing memory overhead and runtime, thanks to @bclyons12's advice

### Changes
- Use `IMAS.trace_simple_surfaces` instead of `IMAS.trace_surfaces`
- Add convenience dispatch method for `trace_simple_surfaces` on `equilibrium__time_slice`
- Update type signatures to use `AbstractFluxSurface` for better flexibility

### Performance Impact
Measured with `@btime run_PAM(dd_D3D; inputs...)`:

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Runtime | 9.51 ms | 5.65 ms | **1.7x faster** |
| Allocations | 108,287 | 8,167 | **13x fewer** |
| Memory | 7.20 MiB | 2.35 MiB | **3x less** |

### Testing
- ✅ Existing tests pass
- ✅ Benchmark verified with D3D template case